### PR TITLE
fix: 补上缺失的 import re，修复下载目录为空 (#5)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -10,6 +10,7 @@
 
 import sys
 import os
+import re
 import argparse
 from typing import List, Dict
 from pep_core import PepCatalog, PepDownloader, XD_ORDER, XK_ORDER_PREFIX, NJ_ORDER, sort_xk_key, sort_nj_key

--- a/webui.py
+++ b/webui.py
@@ -5,6 +5,7 @@
 
 import os
 import sys
+import re
 import time
 import json
 import asyncio
@@ -112,7 +113,7 @@ class TaskManager:
 
                 self.log(f"==================================================")
                 self.log(f"[*] 开始下载教材: [{safe_xd}/{safe_nj}] 《{book_to_download.get('title')}》")
-                downloader.download_book(
+                result = downloader.download_book(
                     book_id=book_to_download["id"],
                     custom_title=book_to_download.get("title"),
                     sub_dir=sub_dir,
@@ -121,7 +122,16 @@ class TaskManager:
                     skip_if_exists=True,
                     clean_temp=True
                 )
+                if result:
+                    with self._lock:
+                        self.status_text = f"已完成：《{book_to_download.get('title')}》"
+                else:
+                    with self._lock:
+                        self.status_text = f"下载失败：《{book_to_download.get('title')}》"
+                    self.log(f"[-] 《{book_to_download.get('title')}》未生成 PDF（可能无法读取页数或页面被拦截）")
             except Exception as e:
+                with self._lock:
+                    self.status_text = f"下载异常：{e}"
                 self.log(f"[-] 下载异常: {e}")
 
             time.sleep(1)
@@ -560,26 +570,44 @@ def index_page():
         }
 
         async function downloadSingle(id) {
-            await fetch('/api/download', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ book_ids: [id] })
-            });
-            pollStatus();
+            try {
+                const res = await fetch('/api/download', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ book_ids: [id] })
+                });
+                const data = await res.json();
+                if (!data.added_count) {
+                    alert('未能加入下载队列，请刷新目录后重试。');
+                    return;
+                }
+                pollStatus();
+            } catch (e) {
+                alert('提交下载失败: ' + e);
+            }
         }
 
         async function downloadSelected() {
             const ids = Array.from(selectedBookIds);
             if (ids.length === 0) return;
-            await fetch('/api/download', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ book_ids: ids })
-            });
-            selectedBookIds.clear();
-            updateSelectionUI();
-            renderBookGrid();
-            pollStatus();
+            try {
+                const res = await fetch('/api/download', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ book_ids: ids })
+                });
+                const data = await res.json();
+                if (!data.added_count) {
+                    alert('未能加入下载队列，请刷新目录后重试。');
+                    return;
+                }
+                selectedBookIds.clear();
+                updateSelectionUI();
+                renderBookGrid();
+                pollStatus();
+            } catch (e) {
+                alert('提交下载失败: ' + e);
+            }
         }
 
         async function refreshCatalog() {


### PR DESCRIPTION
## Summary
- 修复 `webui.py` / `cli.py` 使用 `re.sub` 却未 `import re` 的问题，避免下载 worker 抛出 `NameError` 后目录仍为空（对应 #5）
- WebUI 在下载失败/异常时更新状态文案，并在单本/批量提交失败时给出前端提示

## Test plan
- [x] 本地复现：修复前 `/api/status` 日志出现 `name ''re'' is not defined`
- [x] 修复后点击下载可过 WAF，页图正常写入 `temp_pages/`，最终生成 PDF
- [ ] 维护者在干净环境跑 `python webui.py`，单本与批量下载各测一次
